### PR TITLE
local.conf.sample: Add wic.bmap to IMAGE_FSTYPES.

### DIFF
--- a/conf/templates/default/local.conf.sample
+++ b/conf/templates/default/local.conf.sample
@@ -165,7 +165,7 @@ PACKAGE_CLASSES ?= "package_rpm"
 # We default to enabling the debugging tweaks.
 EXTRA_IMAGE_FEATURES = "debug-tweaks "
 
-IMAGE_FSTYPES = "tar.gz wic"
+#IMAGE_FSTYPES = "tar.gz wic wic.bmap"
 
 #
 # Additional image features


### PR DESCRIPTION
Also comment it out so default is from machine conf file which does not create the bmap file.